### PR TITLE
create local watcher if no host or port option is specified

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# http://editorconfig.org
+
+# this is the top-most .editorconfig file
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = tab
+tab_width = 4
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/bin/remote-filewatcher
+++ b/bin/remote-filewatcher
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+var server = require('../lib/server');
+
+var directory;
+var port = '54545';
+var address = '127.0.0.1';
+
+if (!process.argv[2]) {
+	console.error('Usage: remote-filewatcher <directory> [<listen-port> [<listen-address>]]');
+	process.exit(1);
+}
+
+directory = process.argv[2];
+
+if (process.argv[3]) {
+	port = process.argv[3];
+}
+
+if (process.argv[4]) {
+	address = process.argv[4];
+}
+
+server(directory, port, address);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,9 @@
+var client = require('./client'),
+	filewatcher = require('filewatcher');
+
+module.exports = function(opts) {
+	if (opts.host || opts.port) {
+		return client(opts);
+	}
+	return filewatcher(opts);
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 var client = require('./client'),
+	server = require('./server'),
 	filewatcher = require('filewatcher');
 
 module.exports = function(opts) {
@@ -7,3 +8,5 @@ module.exports = function(opts) {
 	}
 	return filewatcher(opts);
 };
+
+module.exports.server = server;

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,71 +1,55 @@
-#!/usr/bin/env node
 var net = require('net'),
 	path = require('path'),
 	util = require('util'),
 	filewatcher = require('filewatcher'),
 	common = require('./common');
 
-var directory;
-var port = '54545';
-var address = '127.0.0.1';
+module.exports = function(directory, port, address) {
 
-if (!process.argv[2]) {
-	console.error('Usage: remote-filewatcher <directory> [<listen-port> [<listen-address>]]');
-	process.exit(1);
-}
+	var server = net.createServer(function (conn) {
+		var watcher;
 
-directory = process.argv[2];
+		common.withCommandEvents(conn);
 
-if (process.argv[3]) {
-	port = process.argv[3];
-}
+		conn.on('command-options', function (options) {
+			watcher = filewatcher(options);
 
-if (process.argv[4]) {
-	address = process.argv[4];
-}
+			watcher.on('change', function (file, stat) {
+				common.command(conn, 'change', { file: path.relative(directory, file), stat: stat });
+			});
 
-var server = net.createServer(function (conn) {
-	var watcher;
+			watcher.on('fallback', function (limit) {
+				common.command(conn, 'fallback', limit);
+			});
 
-	common.withCommandEvents(conn);
-
-	conn.on('command-options', function (options) {
-		watcher = filewatcher(options);
-
-		watcher.on('change', function (file, stat) {
-			common.command(conn, 'change', { file: path.relative(directory, file), stat: stat });
+			watcher.on('error', function (error) {
+				common.command(conn, 'error', util.inspect(error));
+			});
 		});
 
-		watcher.on('fallback', function (limit) {
-			common.command(conn, 'fallback', limit);
+		conn.on('command-add', function (file) {
+			watcher.add(path.resolve(directory, file));
 		});
 
-		watcher.on('error', function (error) {
-			common.command(conn, 'error', util.inspect(error));
+		conn.on('command-remove', function (file) {
+			watcher.remove(path.resolve(directory, file));
 		});
-	});
 
-	conn.on('command-add', function (file) {
-		watcher.add(path.resolve(directory, file));
-	});
-
-	conn.on('command-remove', function (file) {
-		watcher.remove(path.resolve(directory, file));
-	});
-
-	conn.on('command-remove-all', function () {
-		watcher.removeAll();
-	});
-
-	conn.on('error', function () {
-		// Nothing to do here
-	});
-
-	conn.on('close', function () {
-		if (watcher) {
+		conn.on('command-remove-all', function () {
 			watcher.removeAll();
-		}
-	});
-});
+		});
 
-server.listen(port, address);
+		conn.on('error', function () {
+			// Nothing to do here
+		});
+
+		conn.on('close', function () {
+			if (watcher) {
+				watcher.removeAll();
+			}
+		});
+	});
+
+	server.listen(port, address);
+
+};

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/pepve/remote-filewatcher/issues"
   },
   "dependencies": {
-    "filewatcher": "~2.0.3"
+    "filewatcher": "^2.0.3"
   },
   "devDependencies": {
     "jshint": "^2.5.5"

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "remote-filewatcher",
   "version": "0.0.4",
   "description": "A networked drop-in replacement for filewatcher",
-  "main": "lib/client.js",
   "bin": "lib/server.js",
+  "main": "lib/index.js",
   "scripts": {
     "pretest": "jshint lib",
     "test": "node test/simple.js"

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "remote-filewatcher",
   "version": "0.0.4",
   "description": "A networked drop-in replacement for filewatcher",
-  "bin": "lib/server.js",
   "main": "lib/index.js",
+  "bin": "bin/remote-filewatcher",
   "scripts": {
     "pretest": "jshint lib",
     "test": "node test/simple.js"

--- a/test/simple.js
+++ b/test/simple.js
@@ -10,7 +10,7 @@ var actualStat;
 var changeCount = 0;
 var serverRanToEnd;
 
-var server = child_process.spawn('node', [__dirname + '/../lib/server.js', process.cwd(), '12345'], { stdio: 'inherit' });
+var server = child_process.spawn('node', [__dirname + '/../bin/remote-filewatcher', process.cwd(), '12345'], { stdio: 'inherit' });
 var serverExited = false;
 
 server.on('exit', function() {

--- a/test/simple.js
+++ b/test/simple.js
@@ -1,7 +1,7 @@
 var assert = require('assert'),
 	fs = require('fs'),
 	child_process = require('child_process'),
-	remoteFilewatcher = require('..');
+	remoteFilewatcher = require('../lib/client');
 
 var expectedFile = __dirname + '/foo';
 var actualFile;


### PR DESCRIPTION
With these changes remote-filewatcher can be used as true drop-in replacement as it will behave like a regular local watcher if no remote options are specified.
